### PR TITLE
target = waypoint doesn't exist

### DIFF
--- a/loadouts.txt
+++ b/loadouts.txt
@@ -17,7 +17,7 @@ func healwalk()
   // Heal and gain armor while just walking
   // towards next objective. If 100% healed,
   // walk faster.
-  :?target = waypoint | foe.distance > 22
+  :?foe.distance > 22
     ?hp < maxhp
       equipL ouroboros
       equipR shield *10


### PR DESCRIPTION
you can't access target like this in stonescript.